### PR TITLE
remove intermediate disk write of heapsnapshot

### DIFF
--- a/lib/attach-middleware.js
+++ b/lib/attach-middleware.js
@@ -1,11 +1,7 @@
 const CDP = require("chrome-remote-interface");
 const glob = require("glob");
 const fs = require("fs");
-const { promisify } = require("util");
 const Heapsnapshot = require("heapsnapshot");
-
-const writeFile = promisify(fs.writeFile);
-const unlink = promisify(fs.unlink);
 
 function attachMiddleware({ app, addon }) {
   const config = readConfig(addon);
@@ -116,13 +112,9 @@ async function captureHeapSnapshot(client) {
 
     await client.HeapProfiler.takeHeapSnapshot({ reportProgress: false });
 
-    await writeFile("Heap.heapsnapshot", heapSnapshotChunks.join(""));
+    const parsedHeapSnapshot = JSON.parse(heapSnapshotChunks.join(""));
 
-    const snapshot = Heapsnapshot.fromFileSync("Heap.heapsnapshot");
-
-    await unlink("Heap.heapsnapshot");
-
-    return snapshot;
+    return new Heapsnapshot(parsedHeapSnapshot);
   } catch (e) {
     throw new Error(`error taking heap snapshot: ${e}`);
   }


### PR DESCRIPTION
We were unnecessarily writing the heapsnapshot to disk before reading it and parsing it.
We can just pass the parsed heap snapshot straight into the Heapsnapshot class.