### PR TITLE
Add Tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,7 +33,8 @@ module.exports = {
         'testem.js',
         'blueprints/*/index.js',
         'config/**/*.js',
-        'tests/dummy/config/**/*.js'
+        'tests/dummy/config/**/*.js',
+        'node-tests/**/*.js'
       ],
       excludedFiles: [
         'addon/**',
@@ -46,10 +47,11 @@ module.exports = {
       },
       env: {
         browser: false,
-        node: true
+        node: true,
+        mocha: true
       },
-      plugins: ['node'],
-      extends: ['plugin:node/recommended']
+      plugins: ['node', 'mocha'],
+      extends: ['plugin:node/recommended', 'plugin:mocha/recommended']
     }
   ]
 };

--- a/.npmignore
+++ b/.npmignore
@@ -23,6 +23,7 @@
 /ember-cli-build.js
 /testem.js
 /tests/
+/node-tests/
 /yarn.lock
 .gitkeep
 

--- a/index.js
+++ b/index.js
@@ -22,7 +22,8 @@ module.exports = {
     if (
       type === "test-body-footer" &&
       config["ember-cli-memory-leak-detector"] &&
-      config["ember-cli-memory-leak-detector"].enabled
+      config["ember-cli-memory-leak-detector"].enabled &&
+      this.isEnabled()
     ) {
       const template = fs
         .readFileSync(
@@ -36,10 +37,19 @@ module.exports = {
   },
 
   serverMiddleware({ app }) {
-    attachMiddleware({ app, addon: this });
+    if (this.isEnabled()) {
+      attachMiddleware({ app, addon: this });
+    }
   },
 
   testemMiddleware(app) {
-    attachMiddleware({ app, addon: this });
+    if (this.isEnabled()) {
+      attachMiddleware({ app, addon: this });
+    }
+  },
+
+  isEnabled() {
+    const isDirectDependency = this.parent === this.project;
+    return isDirectDependency;
   },
 };

--- a/lib/attach-middleware.js
+++ b/lib/attach-middleware.js
@@ -8,10 +8,39 @@ function attachMiddleware({ app, addon }) {
   const classes = getAppClasses(addon, config);
 
   app.get("/detect_memory_leak", async function (req, res) {
-    const title = decodeURI(req.query.title);
-    const retainedClasses = await detectMemoryLeak({ title, classes }, config);
-    const payload = buildPayload(retainedClasses, config);
-    res.json(payload);
+    try {
+      addon.ui.startProgress(
+        `${addon.name}: capturing and analyzing heap snapshot...\n`
+      );
+
+      const title = decodeURI(req.query.title);
+      const retainedClasses = await detectMemoryLeak(
+        { title, classes },
+        config
+      );
+
+      addon.ui.stopProgress();
+
+      const message = buildMessage(retainedClasses);
+
+      if (retainedClasses.length) {
+        if (config.error) {
+          addon.ui.writeError({
+            message: `${addon.name}: ${message}`,
+          });
+          res.json({ classes: retainedClasses, error: true });
+        } else {
+          addon.ui.writeWarnLine(`${addon.name}: ${message}`);
+          res.json({ classes: retainedClasses });
+        }
+      } else {
+        addon.ui.writeInfoLine(`${addon.name}: ${message}`);
+        res.json({ classes: retainedClasses });
+      }
+    } catch (error) {
+      addon.ui.writeError({ message: `${addon.name}: ${error}` });
+      res.json({});
+    }
   });
 }
 
@@ -40,49 +69,32 @@ function getClassNameFromFile(fileContents) {
 }
 
 async function detectMemoryLeak({ title, classes }, config) {
-  try {
-    const browserTab = await connectToTestBrowserTab(
-      title,
-      config.remoteDebuggingPort
-    );
-    console.log(`ember-cli-memory-leak-detector: capturing heapsnapshot`);
-    const snapshot = await captureHeapSnapshot(browserTab);
+  const browserTab = await connectToTestBrowserTab(
+    title,
+    config.remoteDebuggingPort
+  );
+  const snapshot = await captureHeapSnapshot(browserTab);
 
-    const classesSet = new Set(classes);
-    const retainedClasses = new Map();
+  const classesSet = new Set(classes);
+  const retainedClasses = new Map();
 
-    for (const node of snapshot) {
-      if (node.type === "object" && classesSet.has(node.name)) {
-        let retainedCount = retainedClasses.get(node.name) || 0;
-        retainedClasses.set(node.name, retainedCount + 1);
-      }
+  for (const node of snapshot) {
+    if (node.type === "object" && classesSet.has(node.name)) {
+      let retainedCount = retainedClasses.get(node.name) || 0;
+      retainedClasses.set(node.name, retainedCount + 1);
     }
-
-    console.log(
-      `ember-cli-memory-leak-detector: ${
-        retainedClasses.size ? "Leak detected" : "All clear"
-      }`
-    );
-    return [...retainedClasses];
-  } catch (e) {
-    console.warn(`ember-cli-memory-leak-detector: ${e}`);
-    return [];
   }
+
+  return [...retainedClasses];
 }
 
-function buildPayload(retainedClasses = [], config) {
-  const message = `ember-cli-memory-leak-detector: Memory leak detected. The following classes were retained after tests completed: ${retainedClasses
-    .map((_class) => `${_class[0]} x${_class[1]}`)
-    .join(", ")}`;
+function buildMessage(retainedClasses = []) {
+  const formattedListOfRetainedClasses = retainedClasses
+    .map(([name, count]) => `${name} x${count}`)
+    .join("\n");
+  const report = `Memory leak detected. The following classes were retained in the heap after tests completed:\n ${formattedListOfRetainedClasses}`;
 
-  if (!retainedClasses.length) {
-    return { classes: [] };
-  } else if (config.error) {
-    return { classes: retainedClasses, error: message };
-  } else {
-    console.warn(`warning: ${message}`);
-    return { classes: retainedClasses };
-  }
+  return retainedClasses.length ? report : "All clear";
 }
 
 async function connectToTestBrowserTab(title, port) {
@@ -106,20 +118,16 @@ async function connectToTestBrowserTab(title, port) {
 }
 
 async function captureHeapSnapshot(client) {
-  try {
-    let heapSnapshotChunks = [];
-    client.on("HeapProfiler.addHeapSnapshotChunk", ({ chunk }) => {
-      heapSnapshotChunks.push(chunk);
-    });
+  let heapSnapshotChunks = [];
+  client.on("HeapProfiler.addHeapSnapshotChunk", ({ chunk }) => {
+    heapSnapshotChunks.push(chunk);
+  });
 
-    await client.HeapProfiler.takeHeapSnapshot({ reportProgress: false });
+  await client.HeapProfiler.takeHeapSnapshot({ reportProgress: false });
 
-    const parsedHeapSnapshot = JSON.parse(heapSnapshotChunks.join(""));
+  const parsedHeapSnapshot = JSON.parse(heapSnapshotChunks.join(""));
 
-    return new Heapsnapshot(parsedHeapSnapshot);
-  } catch (e) {
-    throw new Error(`error taking heap snapshot: ${e}`);
-  }
+  return new Heapsnapshot(parsedHeapSnapshot);
 }
 
 function readConfig(addon) {

--- a/lib/attach-middleware.js
+++ b/lib/attach-middleware.js
@@ -16,7 +16,10 @@ function attachMiddleware({ app, addon }) {
 }
 
 function getAppClasses(addon, config) {
-  const appJsFiles = glob.sync(addon.app.trees.app + "/**/*.js");
+  const appPath =
+    (addon.app.trees.app && addon.app.trees.app._directoryPath) ||
+    addon.app.trees.app;
+  const appJsFiles = glob.sync(appPath + "/**/*.js");
   const classNames = appJsFiles
     .map((file) => {
       const content = fs.readFileSync(file, { encoding: "utf-8" });
@@ -28,15 +31,12 @@ function getAppClasses(addon, config) {
 
 function getClassNameFromFile(fileContents) {
   const _export_default_class = "export default class ";
-  const _extends = " extends ";
   const classNameIndex = fileContents.indexOf(_export_default_class);
-  if (classNameIndex > -1) {
-    const classNameStart = classNameIndex + _export_default_class.length;
-    const classNameEnd = fileContents.indexOf(_extends);
-    return fileContents.slice(classNameStart, classNameEnd);
-  }
+  if (classNameIndex === -1) return false;
 
-  return false;
+  const classNameStart = classNameIndex + _export_default_class.length;
+  const classNameLength = fileContents.slice(classNameStart).indexOf(" ");
+  return fileContents.slice(classNameStart, classNameStart + classNameLength);
 }
 
 async function detectMemoryLeak({ title, classes }, config) {

--- a/lib/attach-middleware.js
+++ b/lib/attach-middleware.js
@@ -45,7 +45,7 @@ async function detectMemoryLeak({ title, classes }, config) {
       title,
       config.remoteDebuggingPort
     );
-    console.log(`Memory leak detector: capturing heapsnapshot`);
+    console.log(`ember-cli-memory-leak-detector: capturing heapsnapshot`);
     const snapshot = await captureHeapSnapshot(browserTab);
     const nodes = [...snapshot];
 
@@ -63,20 +63,18 @@ async function detectMemoryLeak({ title, classes }, config) {
       }
     });
     console.log(
-      `Memory leak detector: ${
-        retainedClasses.length ? "Leak detected" : "All clear"
+      `ember-cli-memory-leak-detector: ${
       }`
     );
     return retainedClasses;
   } catch (e) {
-    console.warn(`Memory leak detector: ${e}`);
+    console.warn(`ember-cli-memory-leak-detector: ${e}`);
     return [];
   }
 }
 
 function buildPayload(retainedClasses = [], config) {
-  const message = `Memory leak detected. The following classes were retained after tests completed: ${retainedClasses
-    .map((c) => c.name)
+  const message = `ember-cli-memory-leak-detector: Memory leak detected. The following classes were retained after tests completed: ${retainedClasses
     .join(", ")}`;
 
   if (!retainedClasses.length) {
@@ -94,12 +92,18 @@ async function connectToTestBrowserTab(title, port) {
     const targets = await CDP.List({ port });
     const testTarget = targets.find((target) => target.title === title);
     if (!testTarget) {
-      throw new Error();
+      throw new Error(
+        `Tab titled "${title}" did not match any of: ${targets
+          .map((t) => `"${t.title}"`)
+          .join(", ")}`
+      );
     }
     const client = await CDP({ target: testTarget, port });
     return client;
   } catch (e) {
-    throw new Error(`Memory leak detector: unable to connect to chrome. ${e}`);
+    throw new Error(
+      `ember-cli-memory-leak-detector: unable to connect to chrome. ${e}`
+    );
   }
 }
 

--- a/lib/attach-middleware.js
+++ b/lib/attach-middleware.js
@@ -47,26 +47,23 @@ async function detectMemoryLeak({ title, classes }, config) {
     );
     console.log(`ember-cli-memory-leak-detector: capturing heapsnapshot`);
     const snapshot = await captureHeapSnapshot(browserTab);
-    const nodes = [...snapshot];
 
-    const retainedClasses = [];
+    const classesSet = new Set(classes);
+    const retainedClasses = new Map();
 
-    classes.forEach((_class) => {
-      let retainedClassNodes = nodes.filter(
-        (node) => node.type === "object" && node.name === _class
-      );
-      if (retainedClassNodes.length > 0) {
-        retainedClasses.push({
-          name: _class,
-          nodes: retainedClassNodes.length,
-        });
+    for (const node of snapshot) {
+      if (node.type === "object" && classesSet.has(node.name)) {
+        let retainedCount = retainedClasses.get(node.name) || 0;
+        retainedClasses.set(node.name, retainedCount + 1);
       }
-    });
+    }
+
     console.log(
       `ember-cli-memory-leak-detector: ${
+        retainedClasses.size ? "Leak detected" : "All clear"
       }`
     );
-    return retainedClasses;
+    return [...retainedClasses];
   } catch (e) {
     console.warn(`ember-cli-memory-leak-detector: ${e}`);
     return [];
@@ -75,6 +72,7 @@ async function detectMemoryLeak({ title, classes }, config) {
 
 function buildPayload(retainedClasses = [], config) {
   const message = `ember-cli-memory-leak-detector: Memory leak detected. The following classes were retained after tests completed: ${retainedClasses
+    .map((_class) => `${_class[0]} x${_class[1]}`)
     .join(", ")}`;
 
   if (!retainedClasses.length) {

--- a/lib/templates/test-body-footer.html
+++ b/lib/templates/test-body-footer.html
@@ -5,7 +5,7 @@
     const json = await response.json();
 
     if (json.error) {
-      throw new Error(json.error);
+      throw new Error('ember-cli-memory-leak-detector: Memory leak detected');
     }
 
     if (callback) {

--- a/node-tests/acceptance/memory-leak-detector-test.js
+++ b/node-tests/acceptance/memory-leak-detector-test.js
@@ -1,0 +1,39 @@
+"use strict";
+
+const assert = require("assert");
+const execa = require("execa");
+
+describe("Acceptance | Memory leak detection", function () {
+  this.timeout(300000);
+
+  it("fails tests when memory leak is detected", async function () {
+    try {
+      await execa("ember", ["test"]);
+    } catch ({ exitCode, stderr }) {
+      assert.strictEqual(exitCode, 1, "Exits with non-zero status code");
+      assert.strictEqual(
+        stderr.includes("LeakyService"),
+        true,
+        "Reports the leaked service"
+      );
+      assert.strictEqual(
+        stderr.includes("NonleakyService"),
+        false,
+        "Does not reports the unleaked service"
+      );
+    }
+  });
+
+  it("passes tests if no memory leaks are detected", async function () {
+    let { exitCode, stdout } = await execa("ember", [
+      "test",
+      "--filter=nonleaky",
+    ]);
+    assert.strictEqual(exitCode, 0, "Exits with a zero status code");
+    assert.strictEqual(
+      stdout.includes("ember-cli-memory-leak-detector: All clear"),
+      true,
+      "Reports that no leaks were detected"
+    );
+  });
+});

--- a/node-tests/acceptance/memory-leak-detector-test.js
+++ b/node-tests/acceptance/memory-leak-detector-test.js
@@ -11,29 +11,17 @@ describe("Acceptance | Memory leak detection", function () {
       await execa("ember", ["test"]);
     } catch ({ exitCode, stderr }) {
       assert.strictEqual(exitCode, 1, "Exits with non-zero status code");
-      assert.strictEqual(
-        stderr.includes("LeakyService"),
-        true,
-        "Reports the leaked service"
-      );
-      assert.strictEqual(
-        stderr.includes("NonleakyService"),
-        false,
-        "Does not reports the unleaked service"
+      assert.match(stderr, /LeakyService/, "Reports the leaked service");
+      assert.doesNotMatch(
+        stderr,
+        /NonleakyService/,
+        "Only reports the leaked service"
       );
     }
   });
 
   it("passes tests if no memory leaks are detected", async function () {
-    let { exitCode, stdout } = await execa("ember", [
-      "test",
-      "--filter=nonleaky",
-    ]);
+    let { exitCode } = await execa("ember", ["test", "--filter=nonleaky"]);
     assert.strictEqual(exitCode, 0, "Exits with a zero status code");
-    assert.strictEqual(
-      stdout.includes("ember-cli-memory-leak-detector: All clear"),
-      true,
-      "Reports that no leaks were detected"
-    );
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-memory-leak-detector",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1528,6 +1528,12 @@
       "resolved": "https://registry.npmjs.org/@types/symlink-or-copy/-/symlink-or-copy-1.2.0.tgz",
       "integrity": "sha512-Lja2xYuuf2B3knEsga8ShbOdsfNOtzT73GyJmZyY7eGl2+ajOqrs8yM5ze0fsSoYwvA6bw7/Qr7OZ7PEEmYwWg=="
     },
+    "@ungap/promise-all-settled": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+      "dev": true
+    },
     "@webassemblyjs/ast": {
       "version": "1.7.11",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.7.11.tgz",
@@ -1879,7 +1885,6 @@
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
       "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -3246,8 +3251,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "binaryextensions": {
       "version": "2.3.0",
@@ -4549,6 +4553,12 @@
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
       "dev": true
     },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
     "browserify-aes": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
@@ -4828,6 +4838,12 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
     "can-symlink": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/can-symlink/-/can-symlink-1.0.0.tgz",
@@ -4902,7 +4918,6 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
       "integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
@@ -4919,7 +4934,6 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
           "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
           "dev": true,
-          "optional": true,
           "requires": {
             "fill-range": "^7.0.1"
           }
@@ -4929,7 +4943,6 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
           "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "to-regex-range": "^5.0.1"
           }
@@ -4938,15 +4951,13 @@
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
           "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "to-regex-range": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
           "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-number": "^7.0.0"
           }
@@ -5883,6 +5894,12 @@
       "requires": {
         "ms": "2.1.2"
       }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -7517,6 +7534,23 @@
             "@babel/plugin-syntax-typescript": "^7.2.0"
           }
         },
+        "execa": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-2.1.0.tgz",
+          "integrity": "sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^3.0.0",
+            "onetime": "^5.1.0",
+            "p-finally": "^2.0.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
         "fs-extra": {
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -7536,6 +7570,15 @@
           "requires": {
             "@types/minimatch": "^3.0.3",
             "minimatch": "^3.0.2"
+          }
+        },
+        "npm-run-path": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
+          "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
           }
         },
         "semver": {
@@ -9505,20 +9548,34 @@
       "dev": true
     },
     "execa": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-2.1.0.tgz",
-      "integrity": "sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz",
+      "integrity": "sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==",
       "dev": true,
       "requires": {
-        "cross-spawn": "^7.0.0",
-        "get-stream": "^5.0.0",
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
         "is-stream": "^2.0.0",
         "merge-stream": "^2.0.0",
-        "npm-run-path": "^3.0.0",
-        "onetime": "^5.1.0",
-        "p-finally": "^2.0.0",
-        "signal-exit": "^3.0.2",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
         "strip-final-newline": "^2.0.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.0.tgz",
+          "integrity": "sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==",
+          "dev": true
+        },
+        "human-signals": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+          "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+          "dev": true
+        }
       }
     },
     "exists-sync": {
@@ -10236,6 +10293,12 @@
         }
       }
     },
+    "flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true
+    },
     "flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -10890,6 +10953,12 @@
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
       "dev": true
     },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
@@ -11105,6 +11174,12 @@
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
       }
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
     },
     "heapsnapshot": {
       "version": "0.0.6",
@@ -11567,7 +11642,6 @@
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "binary-extensions": "^2.0.0"
       }
@@ -12785,6 +12859,334 @@
       "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.4.0.tgz",
       "integrity": "sha1-bQUVYRyKjITkhKogABKbmOmB/ws="
     },
+    "mocha": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.2.1.tgz",
+      "integrity": "sha512-cuLBVfyFfFqbNR0uUKbDGXKGk+UDFe6aR4os78XIrMQpZl/nv7JYHcvP5MFIAb374b2zFXsdgEGwmzMtP0Xg8w==",
+      "dev": true,
+      "requires": {
+        "@ungap/promise-all-settled": "1.1.2",
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.4.3",
+        "debug": "4.2.0",
+        "diff": "4.0.2",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.1.6",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "3.14.0",
+        "log-symbols": "4.0.0",
+        "minimatch": "3.0.4",
+        "ms": "2.1.2",
+        "nanoid": "3.1.12",
+        "serialize-javascript": "5.0.1",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "7.2.0",
+        "which": "2.0.2",
+        "wide-align": "1.1.3",
+        "workerpool": "6.0.2",
+        "yargs": "13.3.2",
+        "yargs-parser": "13.1.2",
+        "yargs-unparser": "2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "dev": true,
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "log-symbols": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+          "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "serialize-javascript": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
+          "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
+          "dev": true,
+          "requires": {
+            "randombytes": "^2.1.0"
+          }
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "workerpool": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.0.2.tgz",
+          "integrity": "sha512-DSNyvOpFKrNusaaUwk+ej6cBj1bmhLcBfj80elGk+ZIo5JSkq+unB1dLKEOcNfJDZgjGICfhQ0Q5TbP0PvF4+Q==",
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "color-convert": {
+              "version": "1.9.3",
+              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+              "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+              "dev": true,
+              "requires": {
+                "color-name": "1.1.3"
+              }
+            },
+            "color-name": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+              "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+              "dev": true
+            }
+          }
+        },
+        "yargs": {
+          "version": "13.3.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+          "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.2"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+              "dev": true,
+              "requires": {
+                "locate-path": "^3.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+              "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+              "dev": true,
+              "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "p-limit": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+              "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+              "dev": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+              "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+              "dev": true,
+              "requires": {
+                "p-limit": "^2.0.0"
+              }
+            },
+            "path-exists": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+              "dev": true
+            }
+          }
+        },
+        "yargs-parser": {
+          "version": "13.1.2",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+          "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
     "morgan": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
@@ -12875,6 +13277,12 @@
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
       "dev": true,
       "optional": true
+    },
+    "nanoid": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
+      "integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==",
+      "dev": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -13103,8 +13511,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "normalize-url": {
       "version": "2.0.1",
@@ -13199,9 +13606,9 @@
       }
     },
     "npm-run-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
-      "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
       "dev": true,
       "requires": {
         "path-key": "^3.0.0"
@@ -14365,7 +14772,6 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
       "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "picomatch": "^2.2.1"
       }
@@ -14590,6 +14996,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
     "requires-port": {
@@ -17372,6 +17784,12 @@
         "isexe": "^2.0.0"
       }
     },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
     "wide-align": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
@@ -17617,10 +18035,48 @@
       "integrity": "sha512-emOFRT9WVHw03QSvN5qor9QQT9+sw5vwxfYweivSMHTcAXPefwVae2FjO7JJjj8hCE4CzPOPeFM83VwT29HCww==",
       "dev": true
     },
+    "yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+          "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+          "dev": true
+        },
+        "decamelize": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+          "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+          "dev": true
+        },
+        "is-plain-obj": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+          "dev": true
+        }
+      }
+    },
     "yeast": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
+      "dev": true
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9384,6 +9384,16 @@
         "regexpp": "^3.0.0"
       }
     },
+    "eslint-plugin-mocha": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-8.0.0.tgz",
+      "integrity": "sha512-n67etbWDz6NQM+HnTwZHyBwz/bLlYPOxUbw7bPuCyFujv7ZpaT/Vn6KTAbT02gf7nRljtYIjWcTxK/n8a57rQQ==",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^2.1.0",
+        "ramda": "^0.27.1"
+      }
+    },
     "eslint-plugin-node": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
@@ -14644,6 +14654,12 @@
           }
         }
       }
+    },
+    "ramda": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
+      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==",
+      "dev": true
     },
     "randombytes": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",
     "start": "ember serve",
-    "test": "npm-run-all lint:* test:*",
+    "test": "npm-run-all lint:* test:node",
     "test:ember": "ember test",
     "test:ember-compatibility": "ember try:each",
     "test:node": "mocha 'node-tests/**/*-test.js'"
@@ -57,6 +57,7 @@
     "ember-try": "^1.4.0",
     "eslint": "^7.8.0",
     "eslint-plugin-ember": "^8.13.0",
+    "eslint-plugin-mocha": "^8.0.0",
     "eslint-plugin-node": "^11.1.0",
     "execa": "^5.0.0",
     "loader.js": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -23,14 +23,15 @@
     "start": "ember serve",
     "test": "npm-run-all lint:* test:*",
     "test:ember": "ember test",
-    "test:ember-compatibility": "ember try:each"
+    "test:ember-compatibility": "ember try:each",
+    "test:node": "mocha 'node-tests/**/*-test.js'"
   },
   "dependencies": {
+    "chrome-remote-interface": "^0.28.2",
     "ember-cli-babel": "^7.22.1",
     "ember-cli-htmlbars": "^5.3.1",
-    "heapsnapshot": "0.0.6",
-    "chrome-remote-interface": "^0.28.2",
-    "glob": "^7.1.6"
+    "glob": "^7.1.6",
+    "heapsnapshot": "0.0.6"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
@@ -57,9 +58,12 @@
     "eslint": "^7.8.0",
     "eslint-plugin-ember": "^8.13.0",
     "eslint-plugin-node": "^11.1.0",
+    "execa": "^5.0.0",
     "loader.js": "^4.7.0",
+    "mocha": "^8.2.1",
     "npm-run-all": "^4.1.5",
-    "qunit-dom": "^1.4.0"
+    "qunit-dom": "^1.4.0",
+    "rimraf": "^3.0.2"
   },
   "engines": {
     "node": "10.* || >= 12"


### PR DESCRIPTION
This adds some basic tests using mocha and execa to assert against the exitCodes and stdout/stderr output of running `ember test` and `ember test --filter=nonleaky`.

A few other included improvements:

- Improves logging to use ember-cli's ui interface for console logging, and consolidates logging into a single method.
- Fixes some bugs encountered when installing this addon into a real production ember app.
- Only runs detection code if the current project is the direct parent of the addon