### PR TITLE
Lib refactor and Readme enhancements

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,7 +29,7 @@ module.exports = {
         '.template-lintrc.js',
         'ember-cli-build.js',
         'index.js',
-        'lib/attach-middleware.js',
+        'lib/**/*.js',
         'testem.js',
         'blueprints/*/index.js',
         'config/**/*.js',

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Configuration
 ------------------------------------------------------------------------------
 
 1. `enabled` (default `true`)
-Set to false to disables memory leak detection.
+Set to false to disables memory leak detection. 
 
 2. `error`: (default `true`)
 By default, an error is thrown when a leak is detected, causing test failure. Set this to false to prevent memory leaks from causing your tests to fail, and instead log a console warning.
@@ -50,12 +50,61 @@ Configures which port to connect to the testem Chrome instance. This value must 
 4. `ignoreClasses`: (default `["App"]`)
 By default, the addon will discover all class names in your app and detect them in the heap snapshot. Use this to ignore specific classes that you expect to leak or plan to fix later. `App` should always be ignored since it will cause false positives in Ember's test environment.
 
+5. `writeSnapshot`: (default `false`)
+Set this to `true` to write the heapsnapshot to disk as `Heap.heapsnapshot`. This is helpful for fixing memory leaks, since the file can be uploaded into Chrome DevTool's Memory panel for analysis.
+
 Usage
 ------------------------------------------------------------------------------
 
 Whenever you run your tests in Chrome, this addon will capture a heap snapshot after the tests complete and search the heap snapshot for any of your app's ES classes. If any app classes are retained in heap snapshot (indicating a memory leak) your test suite will fail and a report of the retained class names will be logged.
 
-This addon works best if your app is using ES class syntax (`export default class MyComponent extends Component {}`) since it detects class names.
+**The effecitveness of this addon is dependent on:**
+1. **The coverage of your test suite.** If leaky code exists in your app but is not exercised by your tests then this add-on can not detect that leaky code.
+2. **Your usage of ES classes.** This addon functions by getting a list of ES classes in your app/addon code and looking for those objects in the heap snapshot. The addon can only detect leaked objects that have a class name defined in your code.
+
+Fixing memory leaks
+------------------------------------------------------------------------------
+
+Once this addon has helped you identify that your app or addon is leaking memory you can begin the process of fixing those memory leaks. 
+
+Fixing memory leaks requires an understanding of how to find leaky application code in a heap snapshot, and an understanding of what code patterns cause memory leaks and how they can be refactored to prevent leaks. Teaching these things is outside the scope of this addon's documentation (for now, contributions welcome!) but there are some existing resources that can help you here.  
+
+1. https://developers.google.com/web/tools/chrome-devtools/memory-problems is a great introduction to memory problems in the browser and the memory tools available in Chrome DevTools.
+
+1. https://github.com/ember-best-practices/memory-leak-examples is a fantastic free ember-centric resource for learning about patterns that cause memory leaks, how to identify leaky code, and how to fix those leaks.
+
+1. https://embermap.com/topics/memory-leaks Another ember-centric resource for learning about memory leaks in the context.
+
+Most of these resources involve running some code/tests and manually capturing and analyzing a heap snapshot in Chrome DevTools. You may find that this addon paired with the `writeSnapshot` config option and `ember test`'s filter flag provide a handy way to speed up those manual processes.
+
+Dealing with large heap snapshots
+-------------------------------------------------------------------------------
+
+Depending on the size of your app and the number of memory leaks it has you may find that the size of your heapsnapshot causes problems during your test runs.
+
+1. Consider setting the `enabled` config to an environment variable for more control over when memory leak detection is run, for example to only run in CI.
+
+```js
+'ember-cli-memory-leak-detector': {
+  enabled: process.env.DETECT_MEMORY_LEAKS || false,
+}
+```
+
+```bash
+$ DETECT_MEMORY_LEAKS=true ember test
+```
+
+2. Allocate extra memory to node
+
+You may find that node's default memory allocation of 512Mb is insufficient for analyzing your app's heap snapshot. In this case you may need to allocate extra memory to node, otherwise node will run out of memory and your test run will crash.
+
+Use the `max_old_space_size` flag to allocate extra memory. The following example increases node's memory to 8Gb.
+
+```bash
+node --max_old_space_size=8192 node_modules/.bin/ember test
+```
+
+Additionally, if you are running memory leak detection in a CI environment, you may need to increase the size of your CI resource.
 
 
 Contributing

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,5 +1,12 @@
 'use strict';
 
-module.exports = function(/* environment, appConfig */) {
-  return { };
+module.exports = function (/* environment, appConfig */) {
+  return {
+    'ember-cli-memory-leak-detector': {
+      enabled: true,
+      error: true,
+      remoteDebuggingPort: 9222,
+      ignoreClasses: ['App'],
+    },
+  };
 };

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,12 +1,13 @@
-'use strict';
+"use strict";
 
 module.exports = function (/* environment, appConfig */) {
   return {
-    'ember-cli-memory-leak-detector': {
+    "ember-cli-memory-leak-detector": {
       enabled: true,
       error: true,
       remoteDebuggingPort: 9222,
-      ignoreClasses: ['App'],
+      ignoreClasses: ["App"],
+      writeSnapshot: false,
     },
   };
 };

--- a/index.js
+++ b/index.js
@@ -32,9 +32,13 @@ module.exports = {
     }
   },
 
+  readConfig() {
+    return this.project.config()[this.name];
+  },
+
   isEnabled() {
     const isDirectDependency = this.parent === this.project;
-    const { enabled } = this.project.config()[this.name];
+    const { enabled } = this.readConfig();
     return isDirectDependency && enabled;
   },
 };

--- a/index.js
+++ b/index.js
@@ -7,24 +7,8 @@ const attachMiddleware = require("./lib/attach-middleware");
 module.exports = {
   name: require("./package").name,
 
-  config() {
-    return {
-      "ember-cli-memory-leak-detector": {
-        enabled: true,
-        error: true,
-        remoteDebuggingPort: 9222,
-        ignoreClasses: ["App"],
-      },
-    };
-  },
-
-  contentFor(type, config) {
-    if (
-      type === "test-body-footer" &&
-      config["ember-cli-memory-leak-detector"] &&
-      config["ember-cli-memory-leak-detector"].enabled &&
-      this.isEnabled()
-    ) {
+  contentFor(type) {
+    if (type === "test-body-footer" && this.isEnabled()) {
       const template = fs
         .readFileSync(
           path.join(__dirname, "lib", "templates", "test-body-footer.html")
@@ -50,6 +34,7 @@ module.exports = {
 
   isEnabled() {
     const isDirectDependency = this.parent === this.project;
-    return isDirectDependency;
+    const { enabled } = this.project.config()[this.name];
+    return isDirectDependency && enabled;
   },
 };

--- a/lib/attach-middleware.js
+++ b/lib/attach-middleware.js
@@ -1,23 +1,23 @@
-const CDP = require("chrome-remote-interface");
-const glob = require("glob");
-const fs = require("fs");
-const Heapsnapshot = require("heapsnapshot");
+const detectMemoryLeak = require("./detect-memory-leak");
+const inventoryClasses = require("./inventory-classes");
 
-function attachMiddleware({ app, addon }) {
-  const config = readConfig(addon);
-  const classes = getClassesToDetect(addon, config);
+module.exports = function attachMiddleware({ app, addon }) {
+  app.get("/detect_memory_leak", handleDetectMemoryLinkRequest(addon));
+};
 
-  app.get("/detect_memory_leak", async function (req, res) {
+function handleDetectMemoryLinkRequest(addon) {
+  return async function (req, res) {
+    const config = addon.readConfig();
     try {
       addon.ui.startProgress(
         `${addon.name}: capturing and analyzing heap snapshot...\n`
       );
 
-      const title = decodeURI(req.query.title);
-      const retainedClasses = await detectMemoryLeak(
-        { title, classes },
-        config
-      );
+      const retainedClasses = await detectMemoryLeak({
+        port: config.remoteDebuggingPort,
+        title: decodeURI(req.query.title),
+        classes: inventoryClasses(addon),
+      });
 
       addon.ui.stopProgress();
 
@@ -41,61 +41,7 @@ function attachMiddleware({ app, addon }) {
       addon.ui.writeError({ message: `${addon.name}: ${error}` });
       res.json({});
     }
-  });
-}
-
-function getClassesToDetect(addon, config) {
-  let isSelf = addon.parent.name() === addon.name;
-  let parentIsAddon = addon.parent.isEmberCLIAddon();
-  let jsPath;
-
-  if (isSelf) {
-    jsPath = "tests/dummy/app";
-  } else if (parentIsAddon) {
-    jsPath = `${addon.parent.root}/addon`;
-  } else {
-    jsPath =
-      (addon.app.trees.app && addon.app.trees.app._directoryPath) ||
-      addon.app.trees.app;
-  }
-  const jsFiles = glob.sync(jsPath + "/**/*.js");
-  const classNames = jsFiles
-    .map((file) => {
-      const content = fs.readFileSync(file, { encoding: "utf-8" });
-      return getClassNameFromFile(content);
-    })
-    .filter((name) => name && !config.ignoreClasses.includes(name));
-  return classNames;
-}
-
-function getClassNameFromFile(fileContents) {
-  const _export_default_class = "export default class ";
-  const classNameIndex = fileContents.indexOf(_export_default_class);
-  if (classNameIndex === -1) return false;
-
-  const classNameStart = classNameIndex + _export_default_class.length;
-  const classNameLength = fileContents.slice(classNameStart).indexOf(" ");
-  return fileContents.slice(classNameStart, classNameStart + classNameLength);
-}
-
-async function detectMemoryLeak({ title, classes }, config) {
-  const browserTab = await connectToTestBrowserTab(
-    title,
-    config.remoteDebuggingPort
-  );
-  const snapshot = await captureHeapSnapshot(browserTab);
-
-  const classesSet = new Set(classes);
-  const retainedClasses = new Map();
-
-  for (const node of snapshot) {
-    if (node.type === "object" && classesSet.has(node.name)) {
-      let retainedCount = retainedClasses.get(node.name) || 0;
-      retainedClasses.set(node.name, retainedCount + 1);
-    }
-  }
-
-  return [...retainedClasses];
+  };
 }
 
 function buildMessage(retainedClasses = []) {
@@ -106,42 +52,3 @@ function buildMessage(retainedClasses = []) {
 
   return retainedClasses.length ? report : "All clear";
 }
-
-async function connectToTestBrowserTab(title, port) {
-  try {
-    const targets = await CDP.List({ port });
-    const testTarget = targets.find((target) => target.title === title);
-    if (!testTarget) {
-      throw new Error(
-        `Tab titled "${title}" did not match any of: ${targets
-          .map((t) => `"${t.title}"`)
-          .join(", ")}`
-      );
-    }
-    const client = await CDP({ target: testTarget, port });
-    return client;
-  } catch (e) {
-    throw new Error(
-      `ember-cli-memory-leak-detector: unable to connect to chrome. ${e}`
-    );
-  }
-}
-
-async function captureHeapSnapshot(client) {
-  let heapSnapshotChunks = [];
-  client.on("HeapProfiler.addHeapSnapshotChunk", ({ chunk }) => {
-    heapSnapshotChunks.push(chunk);
-  });
-
-  await client.HeapProfiler.takeHeapSnapshot({ reportProgress: false });
-
-  const parsedHeapSnapshot = JSON.parse(heapSnapshotChunks.join(""));
-
-  return new Heapsnapshot(parsedHeapSnapshot);
-}
-
-function readConfig(addon) {
-  return addon.project.config()[this.name];
-}
-
-module.exports = attachMiddleware;

--- a/lib/attach-middleware.js
+++ b/lib/attach-middleware.js
@@ -141,7 +141,7 @@ async function captureHeapSnapshot(client) {
 }
 
 function readConfig(addon) {
-  return addon.parent.config()[addon.name];
+  return addon.project.config()[this.name];
 }
 
 module.exports = attachMiddleware;

--- a/lib/detect-memory-leak.js
+++ b/lib/detect-memory-leak.js
@@ -1,0 +1,55 @@
+const CDP = require("chrome-remote-interface");
+const Heapsnapshot = require("heapsnapshot");
+
+module.exports = async function detectMemoryLeak({ title, classes, port }) {
+  const client = await createCDPClient(title, port);
+  const snapshot = await captureHeapSnapshot(client);
+  const retainedClasses = findRetainedClassesInSnapshot(classes, snapshot);
+
+  return retainedClasses;
+};
+
+async function createCDPClient(title, port) {
+  try {
+    const targets = await CDP.List({ port });
+    const testTarget = targets.find((target) => target.title === title);
+    if (!testTarget) {
+      throw new Error(
+        `Tab titled "${title}" did not match any of: ${targets
+          .map((t) => `"${t.title}"`)
+          .join(", ")}`
+      );
+    }
+    const client = await CDP({ target: testTarget, port });
+    return client;
+  } catch (e) {
+    throw new Error(`Unable to connect to chrome. ${e}`);
+  }
+}
+
+async function captureHeapSnapshot(client) {
+  let heapSnapshotChunks = [];
+  client.on("HeapProfiler.addHeapSnapshotChunk", ({ chunk }) => {
+    heapSnapshotChunks.push(chunk);
+  });
+
+  await client.HeapProfiler.takeHeapSnapshot({ reportProgress: false });
+
+  const parsedHeapSnapshot = JSON.parse(heapSnapshotChunks.join(""));
+
+  return new Heapsnapshot(parsedHeapSnapshot);
+}
+
+function findRetainedClassesInSnapshot(classes, snapshot) {
+  const classesSet = new Set(classes);
+  const retainedClasses = new Map();
+
+  for (const node of snapshot) {
+    if (node.type === "object" && classesSet.has(node.name)) {
+      let retainedCount = retainedClasses.get(node.name) || 0;
+      retainedClasses.set(node.name, retainedCount + 1);
+    }
+  }
+
+  return [...retainedClasses];
+}

--- a/lib/detect-memory-leak.js
+++ b/lib/detect-memory-leak.js
@@ -1,9 +1,17 @@
 const CDP = require("chrome-remote-interface");
+const fs = require("fs");
+const { promisify } = require("util");
+const writeFile = promisify(fs.writeFile);
 const Heapsnapshot = require("heapsnapshot");
 
-module.exports = async function detectMemoryLeak({ title, classes, port }) {
+module.exports = async function detectMemoryLeak({
+  title,
+  classes,
+  port,
+  writeSnapshot,
+}) {
   const client = await createCDPClient(title, port);
-  const snapshot = await captureHeapSnapshot(client);
+  const snapshot = await captureHeapSnapshot(client, writeSnapshot);
   const retainedClasses = findRetainedClassesInSnapshot(classes, snapshot);
 
   return retainedClasses;
@@ -27,13 +35,17 @@ async function createCDPClient(title, port) {
   }
 }
 
-async function captureHeapSnapshot(client) {
+async function captureHeapSnapshot(client, writeSnapshot) {
   let heapSnapshotChunks = [];
   client.on("HeapProfiler.addHeapSnapshotChunk", ({ chunk }) => {
     heapSnapshotChunks.push(chunk);
   });
 
   await client.HeapProfiler.takeHeapSnapshot({ reportProgress: false });
+
+  if (writeSnapshot) {
+    await writeFile("Heap.heapsnapshot", heapSnapshotChunks.join(""));
+  }
 
   const parsedHeapSnapshot = JSON.parse(heapSnapshotChunks.join(""));
 

--- a/lib/inventory-classes.js
+++ b/lib/inventory-classes.js
@@ -1,0 +1,40 @@
+const glob = require("glob");
+const fs = require("fs");
+
+module.exports = function inventoryClasses(addon) {
+  const { ignoreClasses } = addon.readConfig();
+  const pathForJsFiles = getPathForJsFiles(addon);
+
+  const jsFiles = glob.sync(`${pathForJsFiles}/**/*.js`);
+  const classNames = jsFiles
+    .map((file) => {
+      const content = fs.readFileSync(file, { encoding: "utf-8" });
+      return getClassNameFromFile(content);
+    })
+    .filter((name) => name && !ignoreClasses.includes(name));
+
+  return classNames;
+};
+
+function getPathForJsFiles(addon) {
+  let isSelf = addon.parent.name() === addon.name;
+  let parentIsAddon = addon.parent.isEmberCLIAddon();
+  if (isSelf) {
+    return "tests/dummy/app";
+  } else if (parentIsAddon) {
+    return `${addon.parent.root}/addon`;
+  } else {
+    let appTree = addon.app.trees.app;
+    return appTree._directoryPath || appTree;
+  }
+}
+
+function getClassNameFromFile(fileContents) {
+  const _export_default_class = "export default class ";
+  const classNameIndex = fileContents.indexOf(_export_default_class);
+  if (classNameIndex === -1) return false;
+
+  const classNameStart = classNameIndex + _export_default_class.length;
+  const classNameLength = fileContents.slice(classNameStart).indexOf(" ");
+  return fileContents.slice(classNameStart, classNameStart + classNameLength);
+}


### PR DESCRIPTION
- Consolidate config logic and use `project.config()`
- Refactors the `lib` folder with better separation of concerns. (fixes #22)
- Improves readme (fixes #13 and #16)
- Adds config option to write snapshot to disk. This facilitates uploading test run heapshots into DevTools for further investigation.