### PR TITLE
Use AST to inventory class names

### DIFF
--- a/lib/inventory-classes.js
+++ b/lib/inventory-classes.js
@@ -1,16 +1,20 @@
 const glob = require("glob");
 const fs = require("fs");
 
+const { parse } = require("@babel/parser");
+const { visit } = require("ast-types");
+
 module.exports = function inventoryClasses(addon) {
   const { ignoreClasses } = addon.readConfig();
   const pathForJsFiles = getPathForJsFiles(addon);
 
-  const jsFiles = glob.sync(`${pathForJsFiles}/**/*.js`);
+  const jsFiles = glob.sync(`${pathForJsFiles}/**/*.{js,ts}`);
   const classNames = jsFiles
     .map((file) => {
       const content = fs.readFileSync(file, { encoding: "utf-8" });
-      return getClassNameFromFile(content);
+      return getClassNamesFromFile(content);
     })
+    .reduce((acc, val) => acc.concat(val), []) // flatten
     .filter((name) => name && !ignoreClasses.includes(name));
 
   return classNames;
@@ -29,12 +33,31 @@ function getPathForJsFiles(addon) {
   }
 }
 
-function getClassNameFromFile(fileContents) {
-  const _export_default_class = "export default class ";
-  const classNameIndex = fileContents.indexOf(_export_default_class);
-  if (classNameIndex === -1) return false;
-
-  const classNameStart = classNameIndex + _export_default_class.length;
-  const classNameLength = fileContents.slice(classNameStart).indexOf(" ");
-  return fileContents.slice(classNameStart, classNameStart + classNameLength);
+function getClassNamesFromFile(fileContents) {
+  let classNames = [];
+  let parserOptions = {
+    sourceType: "module",
+    plugins: [
+      "classProperties",
+      "asyncGenerators",
+      "dynamicImport",
+      "decorators-legacy",
+      "classPrivateProperties",
+      "classPrivateMethods",
+      "nullishCoalescingOperator",
+      "optionalChaining",
+      "typescript",
+      "objectRestSpread",
+    ],
+  };
+  let ast = parse(fileContents, parserOptions);
+  visit(ast, {
+    visitClassDeclaration({ node }) {
+      if (node.id && node.id.name) {
+        classNames.push(node.id.name);
+      }
+      return false; // do not traverse sub-tree
+    },
+  });
+  return classNames;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -284,9 +284,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.12.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.2.tgz",
-      "integrity": "sha512-LMN+SqTiZEonUw4hQA0A3zG8DnN0E1F4K107LbDDUnC+0chML1rvWgsHloC9weB4RmZweE0uhFq0eGX7Nr/PBQ=="
+      "version": "7.12.10",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.10.tgz",
+      "integrity": "sha512-PJdRPwyoOqFAWfLytxrWwGrAxghCgh/yTNCYciOz8QgjflA7aZhECPZAa2VUedKg2+QMWkI0L9lynh2SNmNEgA=="
     },
     "@babel/plugin-proposal-async-generator-functions": {
       "version": "7.12.1",
@@ -2092,10 +2092,19 @@
       "dev": true
     },
     "ast-types": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.3.tgz",
-      "integrity": "sha512-XTZ7xGML849LkQP86sWdQzfhwbt3YwIO6MqbX9mUNYY98VKaaVZP7YNNm70IpwecbkkxmfC5IYAzOQ/2p29zRA==",
-      "dev": true
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz",
+      "integrity": "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==",
+      "requires": {
+        "tslib": "^2.0.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+        }
+      }
     },
     "astral-regex": {
       "version": "1.0.0",
@@ -14798,7 +14807,6 @@
       "integrity": "sha512-XNvYvkfdAN9QewbrxeTOjgINkdY/odTgTS56ZNEWL9Ml0weT4T3sFtvnTuF+Gxyu46ANcRm1ntrF6F5LAJPAaQ==",
       "dev": true,
       "requires": {
-        "ast-types": "0.13.3",
         "esprima": "~4.0.0",
         "private": "^0.1.8",
         "source-map": "~0.6.1"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "test:node": "mocha 'node-tests/**/*-test.js'"
   },
   "dependencies": {
+    "@babel/parser": "^7.12.10",
+    "ast-types": "^0.14.2",
     "chrome-remote-interface": "^0.28.2",
     "ember-cli-babel": "^7.22.1",
     "ember-cli-htmlbars": "^5.3.1",


### PR DESCRIPTION
Fixes #20 

Implements an AST traversal for getting ES class names from the host app/addon's `.js` or `.ts` files.