### PR TITLE
Remove use of private `deprecate` util from `ember-cli`

### DIFF
--- a/packages/ember-cli-memory-leak-detector/index.js
+++ b/packages/ember-cli-memory-leak-detector/index.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const deprecate = require('ember-cli/lib/utilities/deprecate');
 const path = require("path");
 const fs = require("fs");
 const attachMiddleware = require("./lib/attach-middleware");
@@ -51,9 +50,8 @@ module.exports = {
     if (hostEnvConfig && this.isConfigDeprecationTriggered === false) {
       this.isConfigDeprecationTriggered = true;
 
-      deprecate(
-        'Configuring "ember-cli-memory-leak-detector" via "config/environment.js" is deprecated. Please use "ember-cli-build.js" instead.',
-        true
+      console.warn(
+        '\x1b[33mDEPRECATION: Configuring "ember-cli-memory-leak-detector" via "config/environment.js" is deprecated. Please use "ember-cli-build.js" instead.\x1b[0m'
       );
 
       return hostEnvConfig;


### PR DESCRIPTION
Wasn't aware this wasn't meant to be used by addons when implementing https://github.com/steveszc/ember-cli-memory-leak-detector/pull/48.